### PR TITLE
趣味コンポーネントの汎用化

### DIFF
--- a/src/components/Hobbies/index.tsx
+++ b/src/components/Hobbies/index.tsx
@@ -4,54 +4,26 @@ import { MdLibraryMusic, MdLocalCafe } from 'react-icons/md';
 import { Row, Col } from 'antd';
 import './index.css';
 
-// TODO: 趣味の型定義を汎用的にする
 type Hobby = {
-  mk8d: {
-    title: {
-      jp: string;
-      en: string;
-    },
-    description: {
-      jp: string;
-      en: string;
-    }
+  id: string;
+  title: {
+    jp: string;
+    en: string;
   },
-  pokemon: {
-    title: {
-      jp: string;
-      en: string
-    },
-    description: {
-      jp: string;
-      en: string;
-    }
-  },
-  eurobeat: {
-    title: {
-      jp: string;
-      en: string;
-    },
-    description: {
-      jp: string;
-      en: string;
-    }
-  },
-  coffee: {
-    title: {
-      jp: string;
-      en: string;
-    },
-    description: {
-      jp: string;
-      en: string;
-    }
+  description: {
+    jp: string;
+    en: string;
   }
 };
 
 type Props = {
-  hobbies: Hobby;
+  hobbies: Hobby[];
   language: string;
 };
+
+type WrapperProps = {
+  title: string;
+}
 
 function Hobbies(props: Props) {
 
@@ -60,37 +32,46 @@ function Hobbies(props: Props) {
   return (
     <div className="hobbies">
       <Row>
-        <Col className="hobby" xs={24} sm={12} md={12} lg={12} >
-          <div className="hobby-icon"><GiConsoleController size="8em" /></div>
-          <div className="hobby-title"><p>{language === "jp" ? hobbies.mk8d.title.jp : hobbies.mk8d.title.en}</p></div>
-          <div className="hobby-description">
-            <p>{language === "jp" ? hobbies.mk8d.description.jp : hobbies.mk8d.description.en}</p>
-          </div>
-        </Col>
-        <Col className="hobby" xs={24} sm={12} md={12} lg={12} >
-          <div className="hobby-icon"><GiBattleGear size="8em" /></div>
-          <div className="hobby-title"><p>{language === "jp" ? hobbies.pokemon.title.jp : hobbies.pokemon.title.en}</p></div>
-          <div className="hobby-description">
-            <p>{language === "jp" ? hobbies.pokemon.description.jp : hobbies.pokemon.description.en}</p>
-          </div>
-        </Col>
-        <Col className="hobby" xs={24} sm={12} md={12} lg={12} >
-          <div className="hobby-icon"><MdLibraryMusic size="8em" /></div>
-          <div className="hobby-title"><p>{language === "jp" ? hobbies.eurobeat.title.jp : hobbies.eurobeat.title.en}</p></div>
-          <div className="hobby-description">
-            <p>{language === "jp" ? hobbies.eurobeat.description.jp : hobbies.eurobeat.description.en}</p>
-          </div>
-        </Col>
-        <Col className="hobby" xs={24} sm={12} md={12} lg={12} >
-          <div className="hobby-icon"><MdLocalCafe size="8em" /></div>
-          <div className="hobby-title"><p>{language === "jp" ? hobbies.coffee.title.jp : hobbies.coffee.title.en}</p></div>
-          <div className="hobby-description">
-            <p>{language === "jp" ? hobbies.coffee.description.jp : hobbies.coffee.description.en}</p>
-          </div>
-        </Col>
+        { hobbies.map( (hobby, index) => {
+          const { title, description } = hobby;
+          return (
+            <Col className="hobby" xs={24} sm={12} md={12} lg={12} >
+              <div className="hobby-icon"><IconWrapper title={title.jp} /></div>
+              <div className="hobby-title"><p>{language === "jp" ? title.jp : title.en}</p></div>
+              <div className="hobby-description">
+                <p>{language === "jp" ? description.jp : description.en}</p>
+              </div>
+            </Col>
+          );
+        })}
       </Row>
     </div>
   );
 };
+
+// 趣味ごとにアイコンを出し分けるためのラッパー
+// 現状は日本語タイトルを基に判定をしている
+function IconWrapper(props: WrapperProps) {
+
+  const { title } = props;
+
+  if (title === "マリオカート8DX") {
+    return (
+      <GiConsoleController size="8em" />
+    );
+  } else if (title === "ポケモン") {
+    return (
+      <GiBattleGear size="8em" />
+    );
+  } else if (title === "EUROBEAT") {
+    return (
+      <MdLibraryMusic size="8em" />
+    );
+  } else {
+    return (
+      <MdLocalCafe size="8em" />
+    );
+  }
+}
 
 export default Hobbies;

--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -16,8 +16,9 @@ export const description = {
 
 export const switch_code =  "SW: 0195-9221-0829"
 
-export const hobbies = {
-  mk8d: {
+export const hobbies = [
+  {
+    id: nanoid(),
     title: {
       jp: "マリオカート8DX",
       en: "MarioKart8DX"
@@ -27,7 +28,8 @@ export const hobbies = {
       en: "I'm big fan of Daisy. I always run with Daisy. My favorite courses are Hyrule Circuit, GCN Yoshi Circuit and Twisted Mansion."
     }
   },
-  pokemon: {
+  {
+    id: nanoid(),
     title: {
       jp: "ポケモン",
       en: "Pokemon"
@@ -37,7 +39,8 @@ export const hobbies = {
       en: "I'm often at online battle with Sword and Shield. My favorite pokemons are Sirnight, Zangoose and Typhiosion."
     }
   },
-  eurobeat: {
+  {
+    id: nanoid(),
     title: {
       jp: "EUROBEAT",
       en: "Listening EUROBEAT"
@@ -47,7 +50,8 @@ export const hobbies = {
       en: "I prefer to listen EUROBEAT when driving or programming. There is a goog memory from when I was a student because I often listen there."
     }
   },
-  coffee: {
+  {
+    id: nanoid(),
     title: {
       jp: "コーヒー",
       en: "Dripping coffee"
@@ -57,7 +61,7 @@ export const hobbies = {
       en: "I really love coffee. Especially, coffee beans of Brazil, Costa Rica, Peru and Guatemala are my favorite."
     }
   }
-}
+]
 
 export const contents = [
   {


### PR DESCRIPTION
趣味が増えたり変わったりした時のことを考慮して、以下を行った
・`data.ts` から受け取った趣味の数だけ `map` で DOM を描画するよう修正
・アイコンを出し分けるラッパーの作成